### PR TITLE
Ecran des résultats / score final

### DIFF
--- a/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePage.js
+++ b/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePage.js
@@ -1,0 +1,12 @@
+import {connect} from 'react-redux';
+import {getPlayersOrderedByScore} from '../../redux/selectors/playersSelectors';
+import GameScorePageView from './GameScorePageView';
+
+function mapStateToProps(state) {
+  return {
+    players: getPlayersOrderedByScore(state)
+  };
+}
+
+const GameScorePage = connect(mapStateToProps)(GameScorePageView);
+export default GameScorePage;

--- a/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePageView.js
+++ b/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePageView.js
@@ -1,41 +1,25 @@
 import React, { PureComponent } from 'react';
 import { View } from 'react-native';
+import PropTypes, { shape, string, number } from 'prop-types';
 import {
-  Button,
   Container,
   Content,
-  Footer,
-  Form,
-  Icon,
-  Input,
-  Item,
   Label,
-  Left,
-  List,
-  ListItem,
-  Right,
   Body,
   H1
 } from 'native-base';
 
 export class GameScorePageView extends PureComponent {
-  renderResult() {
-    playersList = [
-      {
-        name: 'Fabrice',
-        score: 300
-      },
-      {
-        name: 'Alpha',
-        score: 299
-      },
-      {
-        name: 'Arnaud',
-        score: 12
-      }
-    ];
 
-    const labels = playersList.map((player, index) => {
+  static propTypes = {
+    players: PropTypes.arrayOf(shape({
+      name: string,
+      score: number
+    })).isRequired
+  }
+
+  renderResult() {
+    const labels = this.props.players.map((player, index) => {
       const text = `${player.name}: ${player.score}`;
       return index === 0 ? <H1 key={index}>{text}</H1> : <Label key={index}>{text}</Label>
     });

--- a/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePageView.js
+++ b/workshops/meetup-5-flechettes/src/components/GameScorePage/GameScorePageView.js
@@ -1,10 +1,61 @@
-import React, {PureComponent} from 'react';
-import {View} from 'react-native';
+import React, { PureComponent } from 'react';
+import { View } from 'react-native';
+import {
+  Button,
+  Container,
+  Content,
+  Footer,
+  Form,
+  Icon,
+  Input,
+  Item,
+  Label,
+  Left,
+  List,
+  ListItem,
+  Right,
+  Body,
+  H1
+} from 'native-base';
 
 export class GameScorePageView extends PureComponent {
+  renderResult() {
+    playersList = [
+      {
+        name: 'Fabrice',
+        score: 300
+      },
+      {
+        name: 'Alpha',
+        score: 299
+      },
+      {
+        name: 'Arnaud',
+        score: 12
+      }
+    ];
+
+    const labels = playersList.map((player, index) => {
+      const text = `${player.name}: ${player.score}`;
+      return index === 0 ? <H1 key={index}>{text}</H1> : <Label key={index}>{text}</Label>
+    });
+
+    return (
+      <View style={{ alignItems: 'flex-end' }}>
+        {labels}
+      </View>
+    )
+  }
+
   render() {
     return (
-      <View/>
+      <Container>
+        <Content contentContainerStyle={{ flex: 1 }}>
+          <Body style={{ justifyContent: 'center' }}>
+            {this.renderResult()}
+          </Body>
+        </Content>
+      </Container>
     );
   }
 }

--- a/workshops/meetup-5-flechettes/src/core/routes.js
+++ b/workshops/meetup-5-flechettes/src/core/routes.js
@@ -3,7 +3,7 @@ import PlayerSelectionPage
 import GamePageView from '../components/GamePage/GamePageView';
 import PlayerScorePageView
   from '../components/PlayerScorePage/PlayerScorePageView';
-import GameScorePageView from '../components/GameScorePage/GameScorePageView';
+import GameScorePage from '../components/GameScorePage/GameScorePage';
 
 const routes = {
   playerSelection: {
@@ -22,7 +22,7 @@ const routes = {
       headerTitle: 'Score',
     })
   }, gameScore: {
-    screen: GameScorePageView,
+    screen: GameScorePage,
     navigationOptions: () => ({
       headerTitle: 'Classement',
     })

--- a/workshops/meetup-5-flechettes/src/redux/selectors/playersSelectors.js
+++ b/workshops/meetup-5-flechettes/src/redux/selectors/playersSelectors.js
@@ -1,2 +1,5 @@
 
 export const getPlayers = (state) => (state.players.players);
+export const getPlayersOrderedByScore = (state) => {
+    return state.players.players.sort((a,b) => (a.score < b.score) ? 1 : ((b.score < a.score) ? -1 : 0)); 
+};


### PR DESCRIPTION
Développements réalisés lors du dernier meetup : Ecran de score du jeu simple (résultats).

Pour le tester, il faut modifier en local le fichier routes.js en local pour faire remonter l'écran GameScorePage.
(Actuellement, on n'a pas le cheminement "final" -> saisie joueurs -> jouer -> résultat)